### PR TITLE
Add support for lint-staged

### DIFF
--- a/src/Commands/UnusedCommand.php
+++ b/src/Commands/UnusedCommand.php
@@ -12,6 +12,7 @@ use Illuminate\Console\Command;
 class UnusedCommand extends Command
 {
     public $signature = 'translation:unused
+        {paths?* :  This not used by this command but adds support for lint-staged. }
         {--b|generate-baseline : Generate a baseline file from the unused keys.}';
 
     public $description = 'Finds unused language keys.';

--- a/tests/Commands/UnusedCommandTest.php
+++ b/tests/Commands/UnusedCommandTest.php
@@ -23,7 +23,7 @@ it('errors with default no filters', function () {
     config()->set('translation-linter.unused.filters', []);
 
     withoutMockingConsoleOutput();
-    expect(artisan('translation:unused'))
+    expect(artisan('translation:unused "/this/argument/is/ignored" "/and/so/is/this"'))
         ->toBe(1)
         ->and(Artisan::output())
         ->toMatchSnapshot();


### PR DESCRIPTION
https://github.com/okonet/lint-staged passes in all staged files as paths to the configured commands, 

The laravel (symfony) console throws an exception when you pass an argument to command where the signature for that comand has not been defined to accept arguments.

This adds a `paths` command to the `translation:unused` command but the command has no way of using these arguments as the command itself needs to scan all configured application directories to find out whether a language key is unused. If it ran only against staged files you would end up with false positives. 
