### PR TITLE
chore(deps): update all dev dependencies to latest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,9 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
             carbon: ^3.0
+        exclude:
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
         "illuminate/contracts": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.13",
+        "laravel/pint": "^1.29",
         "nunomaduro/collision": "^8.0",
-        "larastan/larastan": "^3.1",
+        "larastan/larastan": "^3.10",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.0|^4.0",
         "pestphp/pest-plugin-arch": "^3.0|^4.0",
         "pestphp/pest-plugin-laravel": "^3.0|^4.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0"
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0.4",
+        "phpstan/phpstan-phpunit": "^2.0.18"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
         "nunomaduro/collision": "^8.0",
         "larastan/larastan": "^3.1",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-arch": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"

--- a/config/translation-linter.php
+++ b/config/translation-linter.php
@@ -1,5 +1,11 @@
 <?php
 
+use Fidum\LaravelTranslationLinter\Filters\IgnoreDefaultLanguageFilesFilter;
+use Fidum\LaravelTranslationLinter\Filters\IgnoreNamespacedKeysFilter;
+use Fidum\LaravelTranslationLinter\Filters\IgnoreVendorKeysFilter;
+use Fidum\LaravelTranslationLinter\Readers\JsonFileReader;
+use Fidum\LaravelTranslationLinter\Readers\PhpFileReader;
+
 return [
     'application' => [
         /*
@@ -72,8 +78,8 @@ return [
         |
         */
         'readers' => [
-            'json' => \Fidum\LaravelTranslationLinter\Readers\JsonFileReader::class,
-            'php' => \Fidum\LaravelTranslationLinter\Readers\PhpFileReader::class,
+            'json' => JsonFileReader::class,
+            'php' => PhpFileReader::class,
         ],
     ],
 
@@ -177,9 +183,9 @@ return [
         |
         */
         'filters' => [
-            \Fidum\LaravelTranslationLinter\Filters\IgnoreDefaultLanguageFilesFilter::class,
-            \Fidum\LaravelTranslationLinter\Filters\IgnoreNamespacedKeysFilter::class,
-            \Fidum\LaravelTranslationLinter\Filters\IgnoreVendorKeysFilter::class,
+            IgnoreDefaultLanguageFilesFilter::class,
+            IgnoreNamespacedKeysFilter::class,
+            IgnoreVendorKeysFilter::class,
         ],
 
         /*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,8 @@ parameters:
         - src
         - config
     tmpDir: build/phpstan
+    configDirectories:
+        - config
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
     backupGlobals="false"
     bootstrap="vendor/autoload.php"
     colors="true"
@@ -20,16 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
     <source>
         <include>
             <directory suffix=".php">./src</directory>

--- a/src/Finders/ApplicationFileFinder.php
+++ b/src/Finders/ApplicationFileFinder.php
@@ -16,7 +16,7 @@ readonly class ApplicationFileFinder implements ApplicationFileFinderContract
 
     public function execute(): Collection
     {
-        $files = new Collection();
+        $files = new Collection;
 
         foreach ($this->directories as $directory) {
             $files = $files->merge($this->filesystem->allFiles($directory));

--- a/src/Finders/LanguageFileFinder.php
+++ b/src/Finders/LanguageFileFinder.php
@@ -37,6 +37,6 @@ readonly class LanguageFileFinder implements LanguageFileFinderContract
             });
         }
 
-        return new Collection();
+        return new Collection;
     }
 }

--- a/src/Finders/LanguageNamespaceFinder.php
+++ b/src/Finders/LanguageNamespaceFinder.php
@@ -12,7 +12,7 @@ readonly class LanguageNamespaceFinder implements LanguageNamespaceFinderContrac
 
     public function execute(): Collection
     {
-        $namespacesCollection = new Collection();
+        $namespacesCollection = new Collection;
 
         // Get Translator namespaces
         $loader = $this->translator->getLoader();

--- a/src/Parsers/ApplicationFileParser.php
+++ b/src/Parsers/ApplicationFileParser.php
@@ -20,7 +20,7 @@ readonly class ApplicationFileParser implements ApplicationFileParserContract
     public function execute(SplFileInfo $file): Collection
     {
         $data = $file->getContents();
-        $collection = new Collection();
+        $collection = new Collection;
 
         if (! preg_match_all($this->pattern, $data, $matches, PREG_OFFSET_CAPTURE)) {
             // If pattern not found return


### PR DESCRIPTION
## Summary

Updates all dev dependencies to their latest versions and bumps minimum constraints to match.

### Dependency changes
- **Pest 3.7 → 4.7** (+ `pest-plugin-arch`, `pest-plugin-laravel` to 4.x) — `^4.0` added alongside `^3.0` since Pest 4 requires PHP 8.3 and the package still supports 8.2
- **Testbench 10.0 → 11.1** (already allowed by existing constraint)
- Minimum constraint bumps: `laravel/pint` `^1.29`, `larastan/larastan` `^3.10`, `phpstan/extension-installer` `^1.4`, `phpstan/phpstan-deprecation-rules` `^2.0.4`, `phpstan/phpstan-phpunit` `^2.0.18`

### Config fixes required by the major bumps
- **phpunit.xml.dist** — removed forced coverage/junit report blocks (PHPUnit 12 aborts when coverage reports are configured but no driver is installed; `pest --coverage` is unaffected). Schema bumped to 12.5.
- **phpstan.neon.dist** — dropped `checkMissingIterableValueType` (removed in PHPStan 2, no-op at level 4) and registered the package `config` dir for larastan's new `noEnvCallsOutsideOfConfig` rule, which otherwise false-flags `env()` calls in the package config file.
- **Pint** — applied new fixers across 5 files (`new_with_parentheses`, `fully_qualified_strict_types`, etc.)

## Verification
- `vendor/bin/pest` — 16 passed (42 assertions)
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/pint --test` — clean
- `composer validate --strict` — valid